### PR TITLE
Maatregelnummer toegevoegd en ICO verwijderd

### DIFF
--- a/docs/maatregelen/index.md
+++ b/docs/maatregelen/index.md
@@ -446,8 +446,7 @@ Er behoren processen en procedures te worden vastgesteld en geïmplementeerd om 
 
 ## Verplichte overheidsspecifieke maatregelen
 
-### Bij offerteaanvragen waar informatie(voorziening) een rol speelt, zijn eisen ten aanzien van informatiebeveiliging (beschikbaarheid, integriteit en vertrouwelijkheid) onderdeel van het hele pakket aan inkoopeisen. De eisen voor informatiebeveiliging zijn gebaseerd op een expliciete risicoafweging.
-### Bij inkoopsegmenten die op cyberproducten of -diensten betrekking hebben, wordt als uitgangspunt voor de risicoanalyse de maatregelset Inkoopeisen Cybersecurity Overheid gehanteerd.
+### 5.19.01 Bij offerteaanvragen waar informatie(voorziening) een rol speelt, zijn eisen ten aanzien van informatiebeveiliging (beschikbaarheid, integriteit en vertrouwelijkheid) onderdeel van het hele pakket aan inkoopeisen. De eisen voor informatiebeveiliging zijn gebaseerd op een expliciete risicoafweging.
 
 
 Draagt bij aan: Basishygiëne, NIS2, ketenhygiëne


### PR DESCRIPTION
Er was een maatregelnummer weggevallen (5.19.01) en bij die maatregel de tekst over het verplicht gebruik van de Inkoopeisen  Cybersecurity Overheid verwijderd. Dit is besloten in het kern-IBO van 1 april 2025. Deze Inkoopeisen tekst zal nader worden uitgewerkt op een ander moment.

## Beschrijf jouw aanpassingen

## Bij welk issue hoort de pull-request?

## Checklist voordat je een beoordeling aangevraagd
- [x] Ik heb de [contributing guidelines](https://github.com/MinBZK/Baseline-Informatiebeveiliging-Overheid/blob/main/CONTRIBUTING.md) van deze repository gelezen en gevolgd. 
- [x] Ik heb mijn aanpassingen gecheckt op spelfouten.
- [x] Als ik gebruik heb gemaakt van links, dan heb ik gecheckt of deze werken.
- [x] Ik heb gebruik gemaakt van de templates en formats van de BIO2. 
- [x] Deze pull-request gaat naar de juiste branch (in principe mergen we eerst naar de branch `release` alvorens te mergen naar de `main` branch).
