### PR TITLE
Eerste headings H2 maken

### DIFF
--- a/docs/inleiding/index.md
+++ b/docs/inleiding/index.md
@@ -3,7 +3,7 @@
 
 9 januari 2026, versie 1.3 definitief
 
-# COPYRIGHT-NOTITIE
+## COPYRIGHT-NOTITIE
 
 Deel 1 BIO2-kader van de Baseline Informatiebeveiliging Overheid 2 (BIO2) is gestructureerd volgens NEN-EN-ISO/IEC 27001:2023, en deel 2 BIO-overheidsmaatregelen van de BIO2 is gestructureerd volgens NEN-EN-ISO/IEC 27002:2022.
 Entiteiten kunnen kosteloos beschikken over deze normen via NEN connect, het digitale platform van het Nederlands Normalisatie Instituut (NEN).<br><br>
@@ -20,7 +20,7 @@ Het gebruik van informatie uit NEN-EN-ISO/IEC 27001 en NEN-EN-ISO/IEC 27002 in d
 Het gebruik van teksten uit deze normen in de BIO geschiedt met toestemming van NEN.
 Voor meer informatie over de NEN en het gebruik van hun producten zie: www.nen.nl.
 
-# WIJZIGINGSBEHEER
+## WIJZIGINGSBEHEER
 
 | Versie | Datum | Wijziging | Door |
 | :--- | :--- | :--- | :--- |
@@ -30,7 +30,7 @@ Voor meer informatie over de NEN en het gebruik van hun producten zie: www.nen.n
 | 1.2 definitief | 24-09-2025 | Door het OBDO vastgestelde versie. Opmaak in huisstijl. Toevoeging wijzigingsbeheertabel. Overheidsmaatregel 5.18.1 verwijderd vanwege maatregel 5.18.2 en 5.18.3. Overheidsmaatregel 7.07.02 verwijderd vanwege maatregel 7.07.01. | CIP |
 | 1.3 definitief | 09-01-2026| Aanpassingen vanwege BIO2 als wetgeving. Overheidsmaatregelen buiten Cbw-reikwijdte grijs gemarkeerd. 5.24.08 toegevoegd en vanuit 8.08.06 ernaar verwezen. Verwijderd: Derde alinea van 2. Doel van de BIO is in § Cyberbeveiligingswet (Cbw) beschreven. Eerste alinea van 3. Toepassing BIO is beschreven in 1. Leeswijzer. Typen hygiënen en overheidsrisico. 5.21.01 is beschreven in 5.21.03. Nationale in 5.24.07 vanwege Cbw. 5.35.01 is beschreven in Deel 1 BIO2-kader. 7.01.01 is onvoldoende concreet. Eerste alinea van 7.10.02 is beschreven bij 7.10.01. 8.24.03 is indirect beschreven bij 8.24.01. Verplaatste overheidsmaatregelen: Eerste deel van 5.01.01 naar 5.02.01. 5.04.02 naar 5.10.02. 5.04.03 naar 5.10.03. 5.24.06 naar 5.21.05. 5.25.01 naar 5.26.01. 5.26.01 naar 5.25.01. Eerste bullet van 8.01.02 naar 6.03.04. 08.08.06 met een verwijzing naar 5.24.02. | CIP |
 
-# DANKWOORD
+## DANKWOORD
 
 Wij danken iedereen die direct of indirect heeft bijgedragen aan de totstandkoming van de BIO2.
 In willekeurige volgorde danken wij de vertegenwoordigers van de koepelorganisaties (Vereniging van Nederlandse Gemeenten, Interprovinciaal Overleg en Unie van Waterschappen), Chief Information Security Officers (CISO’s) van overheidseniteiten, de Auditdienst Rijk (ADR), de Rijksinspectie Digitale Infrastructuur (RDI), het Nationaal Cyber Security Centrum (NCSC), het Centrum Informatiebeveiliging en Privacybescherming (CIP), de informatiebeveiligingsdienst voor gemeenten (IBD), de leden van de werkgroep BIO, bestuurders en functionarissen van overheden en alle anderen die hebben bijgedragen.<br><br>


### PR DESCRIPTION
Dit zodat de table of contents op de inleiding zichtbaar word. Deze kon niet omgaan met meerdere Heading 1.

<img width="1376" height="509" alt="afbeelding" src="https://github.com/user-attachments/assets/13b89b22-05f7-4ca3-bbeb-58c626d9282e" />
