### PR TITLE
WV #148 | 8.07.02 naar 6.03.05 | bewustwording surfgedrag | WG BIO 21-04-2026

### DIFF
--- a/docs/maatregelen/index.md
+++ b/docs/maatregelen/index.md
@@ -408,6 +408,15 @@ Het management stimuleert hen actief deze periodiek te volgen.
 
 In bewustwordingsprogramma’s komen gedragsaspecten van veilig mobiel werken aan de orde. 
 
+### 6.03.05
+
+Gebruikers zijn voorgelicht over de risico’s van surfgedrag en het klikken op onbekende links.
+
+<p class="note" title="Deze maatregel is gewijzigd voor BIO2 v2.0.">
+  Deze maatregel stond eerder onder 8.07.02 en is verplaatst naar 6.03.05.
+  Zie: <a href="https://github.com/MinBZK/Baseline-Informatiebeveiliging-Overheid/pull/[PR-NUMMER]/changes">Was-wordt</a>
+</p>
+
 ### 6.04.01
 
 Geen overheidsmaatregel, zie inleiding deel 2 BIO-overheidsmaatregelen. 
@@ -550,19 +559,34 @@ De antimalware-software beoordeelt altijd alle downloads.
 
 ### 8.07.02
 
-Gebruikers zijn voorgelicht over de risico’s van surfgedrag en het klikken op onbekende links.
-
-### 8.07.03
-
 De gebruikte antimalware-software en bijbehorende herstelsoftware zijn actueel en wordt ondersteund door periodieke updates.
 
-### 8.07.04
+<p class="note" title="Deze maatregel is gewijzigd voor BIO2 v2.0.">
+  Dit maatregelnummer is gewijzigd. Deze maatregel stond eerder onder 8.07.03. 8.07.02 is verplaatst naar 6.03.05.
+  Zie: <a href="https://github.com/MinBZK/Baseline-Informatiebeveiliging-Overheid/pull/[PR-NUMMER]/changes">Was-wordt</a>
+</p>
+
+### 8.07.03
 
 De malwarescan wordt uitgevoerd op:
 
 - alle omgevingen, bijvoorbeeld op (mail)servers, (desktop)computers en bij de toegangsverlening tot het netwerk van de entiteit;
 - alle gedownloade content voorafgaand aan executie of opslag;
 - alle bestanden die via netwerken of via elke vorm van opslagmedium zijn ontvangen, vóór gebruik of opslag in de eigen omgeving.
+
+<p class="note" title="Deze maatregel is gewijzigd voor BIO2 v2.0.">
+  Dit maatregelnummer is gewijzigd. Deze maatregel stond eerder onder 8.07.04.
+  Zie: <a href="https://github.com/MinBZK/Baseline-Informatiebeveiliging-Overheid/pull/[PR-NUMMER]/changes">Was-wordt</a>
+</p>
+
+### 8.07.04
+
+Dit maatregelnummer is vervallen.
+
+<p class="note" title="Deze maatregel is gewijzigd voor BIO2 v2.0.">
+  De maatregel die eerder onder 8.07.04 stond, is hernummerd naar 8.07.03.
+  Zie: <a href="https://github.com/MinBZK/Baseline-Informatiebeveiliging-Overheid/pull/[PR-NUMMER]/changes">Was-wordt</a>
+</p>
 
 ### 8.08.01
 

--- a/docs/maatregelen/index.md
+++ b/docs/maatregelen/index.md
@@ -414,7 +414,7 @@ Gebruikers zijn voorgelicht over de risico’s van surfgedrag en het klikken op 
 
 <p class="note" title="Deze maatregel is gewijzigd voor BIO2 v2.0.">
   Deze maatregel stond eerder onder 8.07.02 en is verplaatst naar 6.03.05.
-  Zie: <a href="https://github.com/MinBZK/Baseline-Informatiebeveiliging-Overheid/pull/[PR-NUMMER]/changes">Was-wordt</a>
+  Zie: <a href="https://github.com/MinBZK/Baseline-Informatiebeveiliging-Overheid/pull/474/changes">Was-wordt</a>
 </p>
 
 ### 6.04.01
@@ -563,7 +563,7 @@ De gebruikte antimalware-software en bijbehorende herstelsoftware zijn actueel e
 
 <p class="note" title="Deze maatregel is gewijzigd voor BIO2 v2.0.">
   Dit maatregelnummer is gewijzigd. Deze maatregel stond eerder onder 8.07.03. 8.07.02 is verplaatst naar 6.03.05.
-  Zie: <a href="https://github.com/MinBZK/Baseline-Informatiebeveiliging-Overheid/pull/[PR-NUMMER]/changes">Was-wordt</a>
+  Zie: <a href="https://github.com/MinBZK/Baseline-Informatiebeveiliging-Overheid/pull/474/changes">Was-wordt</a>
 </p>
 
 ### 8.07.03
@@ -576,7 +576,7 @@ De malwarescan wordt uitgevoerd op:
 
 <p class="note" title="Deze maatregel is gewijzigd voor BIO2 v2.0.">
   Dit maatregelnummer is gewijzigd. Deze maatregel stond eerder onder 8.07.04.
-  Zie: <a href="https://github.com/MinBZK/Baseline-Informatiebeveiliging-Overheid/pull/[PR-NUMMER]/changes">Was-wordt</a>
+  Zie: <a href="https://github.com/MinBZK/Baseline-Informatiebeveiliging-Overheid/pull/474/changes">Was-wordt</a>
 </p>
 
 ### 8.07.04
@@ -585,7 +585,7 @@ Dit maatregelnummer is vervallen.
 
 <p class="note" title="Deze maatregel is gewijzigd voor BIO2 v2.0.">
   De maatregel die eerder onder 8.07.04 stond, is hernummerd naar 8.07.03.
-  Zie: <a href="https://github.com/MinBZK/Baseline-Informatiebeveiliging-Overheid/pull/[PR-NUMMER]/changes">Was-wordt</a>
+  Zie: <a href="https://github.com/MinBZK/Baseline-Informatiebeveiliging-Overheid/pull/474/changes">Was-wordt</a>
 </p>
 
 ### 8.08.01


### PR DESCRIPTION
## Controlelijst voordat je een beoordeling aangevraagd
- [x] Ik heb de [contributing guidelines](https://github.com/MinBZK/Baseline-Informatiebeveiliging-Overheid/blob/main/CONTRIBUTING.md) van deze repository gelezen en gevolgd.
- [x] Ik heb aanpassingen gecontroleerd op taal- en spelfouten en linken gecontroleerd op werking.
- [x] Deze pull-request gaat naar de juiste branch (in principe mergen we eerst naar de branch `release` alvorens te mergen naar de `main` branch).

Besluit: Werkgroep BIO 21-04-2026
Status: overgenomen
Impact: laag, geen normwijziging
Type wijziging: structurele herindeling en hernummering

Wijzigingen:
- Nieuwe maatregel 6.03.05 toegevoegd.
- Oude 8.07.02 verplaatst naar 6.03.05.
- Oude 8.07.03 hernummerd naar 8.07.02.
- Oude 8.07.04 hernummerd naar 8.07.03.
- 8.07.04 opgenomen als vervallen maatregelnummer.
- Wijzigingsnoten toegevoegd bij 6.03.05, 8.07.02, 8.07.03 en 8.07.04.

Motivering:
Bewustwordingsmaatregelen horen systematisch thuis bij 6.03. De eerdere plaatsing in 8.07 veroorzaakte overlap en versnippering.
