### PR TITLE
WV #400 | 5.23.01 | herzieningstermijn CSP-beleid | WG BIO 21-04-2026

### DIFF
--- a/docs/maatregelen/index.md
+++ b/docs/maatregelen/index.md
@@ -262,10 +262,16 @@ De entiteit heeft een actuele registratie van leveranciers en afgesloten contrac
 
 ### 5.23.01
 
-De entiteit stelt beleid op dat toeziet op het inventariseren, classificeren, selecteren, beoordelen en managen van Cloud Service Providers (CSP) en het beëindigen van dienstverlening door CSP’s en past dat toe.<br><br>
-Dit beleid wordt minimaal eens per drie jaar herzien.<br><br>
-In de inkoopcontracten wordt opgenomen welke situaties aanleiding kunnen geven tot ontbinding van het contract.<br><br>
+De entiteit stelt beleid op dat toeziet op het inventariseren, classificeren, selecteren, beoordelen en managen van Cloud Service Providers (CSP) en het beëindigen van dienstverlening door CSP’s en past dat toe.
+
+In de inkoopcontracten wordt opgenomen welke situaties aanleiding kunnen geven tot ontbinding van het contract.
+
 Wanneer zich belangrijke wijzigingen bij de leverancier optreden, beoordeel de risico’s daarvan en neem passende maatregelen.
+
+<p class="note" title="Deze maatregel is gewijzigd voor BIO2 v2.0.">
+  De afzonderlijke herzieningstermijn voor CSP-beleid is geschrapt. Het CSP-beleid valt onder de reguliere beleidsevaluatiecyclus.
+  Zie: <a href="https://github.com/MinBZK/Baseline-Informatiebeveiliging-Overheid/pull/[PR-NUMMER]/changes">Was-wordt</a>
+</p>
 
 ### 5.24.01
 

--- a/docs/maatregelen/index.md
+++ b/docs/maatregelen/index.md
@@ -270,7 +270,7 @@ Wanneer zich belangrijke wijzigingen bij de leverancier optreden, beoordeel de r
 
 <p class="note" title="Deze maatregel is gewijzigd voor BIO2 v2.0.">
   De afzonderlijke herzieningstermijn voor CSP-beleid is geschrapt. Het CSP-beleid valt onder de reguliere beleidsevaluatiecyclus.
-  Zie: <a href="https://github.com/MinBZK/Baseline-Informatiebeveiliging-Overheid/pull/[PR-NUMMER]/changes">Was-wordt</a>
+  Zie: <a href="https://github.com/MinBZK/Baseline-Informatiebeveiliging-Overheid/pull/475/changes">Was-wordt</a>
 </p>
 
 ### 5.24.01


### PR DESCRIPTION
## Controlelijst voordat je een beoordeling aangevraagd
- [x] Ik heb de [contributing guidelines](https://github.com/MinBZK/Baseline-Informatiebeveiliging-Overheid/blob/main/CONTRIBUTING.md) van deze repository gelezen en gevolgd.
- [x] Ik heb aanpassingen gecontroleerd op taal- en spelfouten en linken gecontroleerd op werking.
- [x] Deze pull-request gaat naar de juiste branch (in principe mergen we eerst naar de branch `release` alvorens te mergen naar de `main` branch).

Besluit: Werkgroep BIO 21-04-2026
Status: overgenomen
Impact: Middel-Laag
Type wijziging: tekstuele schrapping, geen normatieve verzwakking

Wijziging:
- De zin “Dit beleid wordt minimaal eens per drie jaar herzien.” is geschrapt uit maatregel 5.23.01.
- De overige normtekst van 5.23.01 blijft ongewijzigd.
- Een -tijdelijke- wijzigingsnoot is toegevoegd bij 5.23.01.

Motivering:
De aparte herzieningstermijn voor CSP-beleid past niet goed in de BIO-systematiek. Het CSP-beleid is afgeleid informatiebeveiligingsbeleid en valt onder de reguliere beleidsevaluatiecyclus, waaronder 5.01.02 en de ISMS/PDCA-cyclus.
