### PR TITLE
BIO2 v2.0 #444 - bewaartermijnen herformuleerd met IB-focus

### DIFF
--- a/docs/maatregelen/index.md
+++ b/docs/maatregelen/index.md
@@ -362,7 +362,7 @@ Geen overheidsmaatregel, zie inleiding deel 2 BIO-overheidsmaatregelen.
 ```De proceseigenaar heeft voor informatie(systemen) bewaartermijnen vastgesteld en ingericht, zodanig dat gegevens niet langer beschikbaar en toegankelijk zijn dan noodzakelijk voor het beperken van het aanvalsoppervlak en het beheersen van risico's bij datalekken```<br><br>
 ```De proceseigenaar heeft deze termijnen ook praktisch ingeregeld en toetst periodiek de werking hiervan.```
 
-<p class="note" title="Deze maatregel is gewijzigd voor BIO2 v2.0."> De maatregel is herformuleerd met een expliciete informatiebeveiligingsfocus. Zie: <a href="https://github.com/MinBZK/Baseline-Informatiebeveiliging-Overheid/pull/[PR-NUMMER]/changes">Was-wordt</a> </p>
+<p class="note" title="Deze maatregel is gewijzigd voor BIO2 v2.0."> De maatregel is herformuleerd met een expliciete informatiebeveiligingsfocus. Zie: <a href="https://github.com/MinBZK/Baseline-Informatiebeveiliging-Overheid/pull/476/changes">Was-wordt</a> </p>
 
 ### 5.34.01
 

--- a/docs/maatregelen/index.md
+++ b/docs/maatregelen/index.md
@@ -359,8 +359,10 @@ Geen overheidsmaatregel, zie inleiding deel 2 BIO-overheidsmaatregelen.
 
 ### 5.33.01 
 
-```De proceseigenaar heeft voor alle informatie(systemen) in selectielijsten de bewaartermijn vastgelegd, rekening houdend met de eigen bedrijfsdoelstellingen en wet- en regeling, zoals de archiefwet en privacywetgeving.```<br><br>
+```De proceseigenaar heeft voor informatie(systemen) bewaartermijnen vastgesteld en ingericht, zodanig dat gegevens niet langer beschikbaar en toegankelijk zijn dan noodzakelijk voor het beperken van het aanvalsoppervlak en het beheersen van risico's bij datalekken```<br><br>
 ```De proceseigenaar heeft deze termijnen ook praktisch ingeregeld en toetst periodiek de werking hiervan.```
+
+<p class="note" title="Deze maatregel is gewijzigd voor BIO2 v2.0."> De maatregel is herformuleerd met een expliciete informatiebeveiligingsfocus. Zie: <a href="https://github.com/MinBZK/Baseline-Informatiebeveiliging-Overheid/pull/[PR-NUMMER]/changes">Was-wordt</a> </p>
 
 ### 5.34.01
 


### PR DESCRIPTION
## Controlelijst voordat je een beoordeling aangevraagd
- [x] Ik heb de [contributing guidelines](https://github.com/MinBZK/Baseline-Informatiebeveiliging-Overheid/blob/main/CONTRIBUTING.md) van deze repository gelezen en gevolgd.
- [x] Ik heb aanpassingen gecontroleerd op taal- en spelfouten en linken gecontroleerd op werking.
- [x] Deze pull-request gaat naar de juiste branch (in principe mergen we eerst naar de branch `release` alvorens te mergen naar de `main` branch).

WV #444 | 5.33.01 | bewaartermijnen met IB-focus | WG BIO 16-06-2026

PR-beschrijving:

Besluit: Werkgroep BIO 16-06-2026
Status: overgenomen
Impact: Middel-laag
Type wijziging: herformulering met informatiebeveiligingsfocus

Wijziging:
- Maatregel 5.33.01 is herformuleerd.
- De verwijzing naar selectielijsten, Archiefwet en privacywetgeving is uit de normtekst gehaald.
- De maatregel richt zich nu op beschikbaarheid en toegankelijkheid van gegevens vanuit informatiebeveiliging.
- Een -tijdelijke- wijzigingsnoot is toegevoegd bij 5.33.01.

Motivering:
De werkgroep heeft een herformulering van de maatregel vastgesteld. Bewaartermijnen blijven relevant voor informatiebeveiliging, omdat gegevens die langer beschikbaar of toegankelijk blijven dan noodzakelijk het aanvalsoppervlak vergroten en risico's bij datalekken verhogen.

De Archiefwet en privacywetgeving regelen bewaartermijnen vanuit hun eigen wettelijke perspectief. De BIO-maatregel wordt daarom beperkt tot het informatiebeveiligingsperspectief: het beperken van beschikbaarheid en toegankelijkheid waar dat nodig is voor risicobeheersing.
