### PR TITLE
Wijzig 7.07.01 toegangsbeveiligingsvergrendeling (#115)

### DIFF
--- a/docs/maatregelen/index.md
+++ b/docs/maatregelen/index.md
@@ -483,7 +483,7 @@ Werkplekken en sessies worden automatisch vergrendeld wanneer de gebruiker de we
 
 <p class="note" title="Deze maatregel is gewijzigd voor BIO2 v2.0.">
  Maatregel gewijzigd naar technologieonafhankelijke vergrendeling.
-  Zie: <a href="https://github.com/MinBZK/Baseline-Informatiebeveiliging-Overheid/pull/.../changes">Was-wordt</a>
+  Zie: <a href="https://github.com/MinBZK/Baseline-Informatiebeveiliging-Overheid/pull/482/changes">Was-wordt</a>
 </p>
 
 ### 7.08.01

--- a/docs/maatregelen/index.md
+++ b/docs/maatregelen/index.md
@@ -479,7 +479,12 @@ Geen overheidsmaatregel, zie inleiding deel 2 BIO-overheidsmaatregelen.
 
 ### 7.07.01
 
-Bij het gebruik van een chipcardtoken voor toegang tot systemen wordt bij het verwijderen van het token de toegangsbeveiligingsvergrendeling automatisch geactiveerd.
+Werkplekken en sessies worden automatisch vergrendeld wanneer de gebruiker de werkplek verlaat of na een ingestelde periode van inactiviteit.
+
+<p class="note" title="Deze maatregel is gewijzigd voor BIO2 v2.0.">
+ Maatregel gewijzigd naar technologieonafhankelijke vergrendeling.
+  Zie: <a href="https://github.com/MinBZK/Baseline-Informatiebeveiliging-Overheid/pull/.../changes">Was-wordt</a>
+</p>
 
 ### 7.08.01
 


### PR DESCRIPTION
… (#115)

## Controlelijst voordat je een beoordeling aangevraagd
- [x] Ik heb de [contributing guidelines](https://github.com/MinBZK/Baseline-Informatiebeveiliging-Overheid/blob/main/CONTRIBUTING.md) van deze repository gelezen en gevolgd.
- [x] Ik heb aanpassingen gecontroleerd op taal- en spelfouten en linken gecontroleerd op werking.
- [x] Deze pull-request gaat naar de juiste branch (in principe mergen we eerst naar de branch `release` alvorens te mergen naar de `main` branch).

## Wijzigingsverzoek

WV #115 | Maatregel 7.07.01 | Werkgroep BIO 14-07-2026

## Besluit

De Werkgroep BIO heeft op 14 juli 2026 ingestemd met het technologieonafhankelijk en resultaatgericht formuleren van maatregel 7.07.01.

## Impact

Middel-laag

## Type wijziging

Verduidelijking en herformulering van een bestaande maatregel.

## Wijzigingen

- De specifieke verwijzing naar een chipcardtoken is verwijderd.
- De maatregel is technologieonafhankelijk geformuleerd.
- Werkplekken en sessies moeten automatisch worden vergrendeld bij het verlaten van de werkplek of na een ingestelde periode van inactiviteit.
- Een FAQ zal worden toegevoegd met voorbeelden van passende mechanismen.

## Motivering

De huidige tekst schrijft feitelijk één technische oplossing voor. De nieuwe tekst beschrijft het vereiste resultaat en laat de technische invulling over aan de entiteit, op basis van risicoanalyse, fysieke werkomgeving, type systeem en classificatie van informatie.
