### PR TITLE
Verduidelijk generieke tekst zonder overheidsmaatregel (#465)

### DIFF
--- a/docs/maatregelen/index.md
+++ b/docs/maatregelen/index.md
@@ -52,7 +52,7 @@ Geen overheidsmaatregel; de implementatierichtlijn uit NEN-EN-ISO/IEC 27002 is l
 
 <p class="note" title="Deze maatregel is gewijzigd voor BIO2 v2.0.">
  Verduidelijking generieke tekst zonder overheidsmaatregel. Deze wijziging wordt verwerkt op alle plaatsen waar de generieke tekst bij een beheersmaatregel zonder overheidsmaatregel voorkomt.
-  Zie: <a href="https://github.com/MinBZK/Baseline-Informatiebeveiliging-Overheid/pull/.../changes">Was-wordt</a>
+  Zie: <a href="https://github.com/MinBZK/Baseline-Informatiebeveiliging-Overheid/pull/488/changes">Was-wordt</a>
 </p>
 
 

--- a/docs/maatregelen/index.md
+++ b/docs/maatregelen/index.md
@@ -48,7 +48,13 @@ Er is een CISO aangesteld die bevoegd is om onafhankelijk en zelfstandig te advi
 
 ### 5.03.01
 
-Geen overheidsmaatregel, zie inleiding deel 2 BIO-overheidsmaatregelen.
+Geen overheidsmaatregel; de implementatierichtlijn uit NEN-EN-ISO/IEC 27002 is leidend.
+
+<p class="note" title="Deze maatregel is gewijzigd voor BIO2 v2.0.">
+ Verduidelijking generieke tekst zonder overheidsmaatregel. Deze wijziging wordt verwerkt op alle plaatsen waar de generieke tekst bij een beheersmaatregel zonder overheidsmaatregel voorkomt.
+  Zie: <a href="https://github.com/MinBZK/Baseline-Informatiebeveiliging-Overheid/pull/.../changes">Was-wordt</a>
+</p>
+
 
 ### 5.04.01
 


### PR DESCRIPTION
## Controlelijst voordat je een beoordeling aangevraagd
- [x] Ik heb de [contributing guidelines](https://github.com/MinBZK/Baseline-Informatiebeveiliging-Overheid/blob/main/CONTRIBUTING.md) van deze repository gelezen en gevolgd.
- [x] Ik heb aanpassingen gecontroleerd op taal- en spelfouten en linken gecontroleerd op werking.
- [x] Deze pull-request gaat naar de juiste branch (in principe mergen we eerst naar de branch `release` alvorens te mergen naar de `main` branch).

## Wijzigingsverzoek
WV #465 | Deel 2, algemeen | Werkgroep BIO 16-06-2026

## Besluit
Het Kernteam BIO heeft besloten de generieke tekst bij beheersmaatregelen zonder overheidsmaatregel zelfdragend te maken.
De Werkgroep BIO is hierover geïnformeerd.

## Status
Goedgekeurd voor verwerking in BIO2 v2.0.

## Impact
Laag

## Type wijziging
Redactionele verduidelijking.

## Wijzigingen
- De verwijzing naar de niet herkenbare inleiding van deel 2 is uit de generieke standaardtekst verwijderd.
- De tekst vermeldt voortaan rechtstreeks dat de implementatierichtlijn uit NEN-EN-ISO/IEC 27002 leidend is.
- Een FAQ is toegevoegd met uitleg over de samenhang met deel 1 en de inleiding van deel 2.

## Motivering
De huidige standaardtekst verwijst naar een inleiding die voor lezers niet duidelijk herkenbaar is. Daardoor is niet direct duidelijk welke implementatierichting geldt.

De nieuwe tekst is zelfstandig leesbaar. De status en werking van ISO-beheersmaatregelen en BIO-overheidsmaatregelen veranderen niet.
