### PR TITLE
Verduidelijking rol en positie CISO

### DIFF
--- a/docs/kader/index.md
+++ b/docs/kader/index.md
@@ -225,9 +225,17 @@ De CISO:
 
 - is verantwoordelijk voor de coördinatie van informatiebeveiliging;
 - ondersteunt de bestuurder en geeft gevraagd en ongevraagd advies aan de bestuurder;
-- vertaalt wetgeving en bedrijfsdoelstellingen naar een informatiebeveiligingsbeleid;
-- rapporteert aan het bestuur hoe het lijnmanagement het informatiebeveiligingsbeleid implementeert en op welke wijze wordt voldaan aan de BIO, om ervoor zorg te dragen dat de bestuurder geïnformeerde besluiten kan maken over de behandeling van informatiebeveiligingsrisico’s;
-- is uitdrukkelijk niet verantwoordelijk voor informatiebeveiliging door het lijnmanagement.
+- adviseert over de vertaling van wetgeving, dreigingen, risico’s en organisatiedoelstellingen naar informatiebeveiligingsbeleid;
+- rapporteert aan het bestuur over de staat van informatiebeveiliging en over de wijze waarop het lijnmanagement het informatiebeveiligingsbeleid implementeert en voldoet aan de BIO;
+- vertaalt informatiebeveiligingsrisico’s naar handelingsperspectief voor de bestuurder;
+- is uitdrukkelijk niet verantwoordelijk voor de uitvoering van informatiebeveiliging door het lijnmanagement.
+
+Verantwoording aan het controlerend orgaan loopt via het bestuur en de reguliere verantwoordingscyclus.
+
+<p class="note" title="Deze paragraaf is gewijzigd voor BIO2 v2.0.">
+  Verduidelijking positionering en rol CISO
+  Zie: <a href="https://github.com/MinBZK/Baseline-Informatiebeveiliging-Overheid/pull/489/changes">Was-wordt</a>
+</p>
 
 ### 12.4 Interne toezichthouder
 

--- a/docs/maatregelen/index.md
+++ b/docs/maatregelen/index.md
@@ -44,7 +44,12 @@ Lijnmanagers en proceseigenaren die verantwoordelijk zijn voor bedrijfsmiddelen 
 
 ### 5.02.02
 
-Er is een CISO aangesteld die bevoegd is om onafhankelijk en zelfstandig te adviseren en te rapporteren aan het bestuur en of het controlerend orgaan over informatiebeveiliging.
+Er is een CISO aangesteld die bevoegd is om zelfstandig en onafhankelijk te adviseren en te rapporteren aan het bestuur over de staat van informatiebeveiliging.
+
+<p class="note" title="Deze maatregel is gewijzigd voor BIO2 v2.0.">
+  Verduidelijking positionering en rol CISO
+  Zie: <a href="https://github.com/MinBZK/Baseline-Informatiebeveiliging-Overheid/pull/489/changes">Was-wordt</a>
+</p>
 
 ### 5.03.01
 
@@ -289,7 +294,12 @@ Er is een meldprocedure waarin de taken en verantwoordelijkheden van het meldlok
 
 ### 5.24.03
 
-De proceseigenaar is verantwoordelijk voor het oplossen van informatiebeveiligingsincidenten.
+De proceseigenaar is verantwoordelijk voor het (laten) oplossen van informatiebeveiligingsincidenten. De incidentmanagementfunctie coördineert bij domeinoverstijgende incidenten.
+
+<p class="note" title="Deze maatregel is gewijzigd voor BIO2 v2.0.">
+  Verduidelijking rol proceseigenaar
+  Zie: <a href="https://github.com/MinBZK/Baseline-Informatiebeveiliging-Overheid/pull/489/changes">Was-wordt</a>
+</p>
 
 ### 5.24.04
 


### PR DESCRIPTION
## Controlelijst voordat je een beoordeling aangevraagd
- [x] Ik heb de [contributing guidelines](https://github.com/MinBZK/Baseline-Informatiebeveiliging-Overheid/blob/main/CONTRIBUTING.md) van deze repository gelezen en gevolgd.
- [x] Ik heb aanpassingen gecontroleerd op taal- en spelfouten en linken gecontroleerd op werking.
- [x] Deze pull-request gaat naar de juiste branch (in principe mergen we eerst naar de branch `release` alvorens te mergen naar de `main` branch).

## Wijzigingsverzoek
Issues #399, #154, #112 en #123 | CISO-positionering en rol | Werkgroep BIO 16-06-2026 en 14-07-2026

## Besluit
De Werkgroep BIO heeft ingestemd met verduidelijking van de positionering, rapportagelijn en verantwoordelijkheden van de CISO. Besluitvorming over aanvullende formele bescherming van de CISO is aangehouden voor nader onderzoek.

## Impact
- CISO-positionering en rapportagelijn: Middel-laag
- Verantwoordelijkheidsverdeling incidenten: Laag

## Type wijziging
Inhoudelijke verduidelijking van rollen, verantwoordelijkheden en rapportagelijnen.

## Wijzigingen
- Paragraaf 12.3 is in lijn gebracht met maatregel 5.02.02.
- De CISO rapporteert aan het bestuur.
- De CISO adviseert, coördineert, monitort en rapporteert onafhankelijk.
- Het lijnmanagement blijft verantwoordelijk voor uitvoering.
- De proceseigenaar blijft verantwoordelijk voor het (laten) oplossen van incidenten.
- De incidentmanagementfunctie coördineert bij domeinoverstijgende incidenten.
- FAQ’s verduidelijken onafhankelijkheid en coördinatie.
- Formele bescherming van de CISO is niet in deze wijziging opgenomen.

## Motivering
De bestaande teksten bevatten onduidelijkheid over de rapportagelijn en kunnen de indruk wekken dat de CISO verantwoordelijk is voor beleidseigenaarschap of operationele uitvoering.
De nieuwe teksten scheiden onafhankelijke advisering en rapportage duidelijk van bestuurlijke, lijn- en proceseigenaarverantwoordelijkheden.
