### PR TITLE
Herzie technisch testpakket 8.08.04 en 8.08.05 (#131 #136)

### DIFF
--- a/docs/maatregelen/index.md
+++ b/docs/maatregelen/index.md
@@ -636,13 +636,28 @@ In de tussentijd of als installatie binnen een week niet mogelijk is, worden op 
 
 ### 8.08.04
 
-Informatiesystemen worden waar mogelijk jaarlijks gecontroleerd op technische naleving van beveiligingsnormen en risico’s van de feitelijke veiligheid. Dit kan bijvoorbeeld door (geautomatiseerde) kwetsbaarheidsanalyses, penetratietesten of red-teamingstesten. Internetfacing-informatiesystemen worden waar mogelijk continue getest op zwakheden en kwetsbaarheden.
+Informatiesystemen worden periodiek en ten minste jaarlijks gecontroleerd op technische naleving van beveiligingsnormen en de feitelijke veiligheidsstatus. De wijze en frequentie van controleren worden bepaald op basis van een risicoafweging, passend bij de classificatie, het dreigingsbeeld en het belang van het informatiesysteem.
+
+De overweging welke methodiek wordt ingezet, van scans tot red teaming, maakt expliciet onderdeel uit van deze risicoafweging. Internetfacing-informatiesystemen worden continu automatisch gescand of getest op zwakheden en kwetsbaarheden.
+
+De controle wordt aantoonbaar uitgevoerd; ten minste methode, bevindingen, beoordeling en opvolging worden vastgelegd. Onderdeel van de beoordeling is tevens de analyse van de root-cause en de verificatie of de kwetsbaarheid ook op andere systemen aanwezig is.
+
+<p class="note" title="Deze maatregel is gewijzigd voor BIO2 v2.0.">
+ Inhoudelijke verduidelijking en aanscherping van het technische testregime.
+ Zie: <a href="https://github.com/MinBZK/Baseline-Informatiebeveiliging-Overheid/pull/.../changes">Was-wordt</a>
+</p>
 
 ### 8.08.05
 
-Internetfacing-informatiesystemen hebben een verplichte waar mogelijk geautomatiseerde penetratietest bij iedere nieuwe release of major update.<br><br>
-Als daar bevindingen met een hoog risico uitkomen die niet op een andere manier gemitigeerd kunnen worden, mag het systeem niet in productie.<br><br>
-Alle internetfacing-informatiesystemen worden minimaal jaarlijks getest op zwakheden en kwetsbaarheden.
+Voor internetfacing-informatiesystemen wordt een penetratietest uitgevoerd bij ingebruikname of bij een majeure wijziging.
+
+Als uit de penetratietest bevindingen met een hoog risico komen die niet op een andere manier zijn gemitigeerd, mag het systeem niet in productie worden genomen.
+
+<p class="note" title="Deze maatregel is gewijzigd voor BIO2 v2.0.">
+ Inhoudelijke verduidelijking en aanscherping van het technische testregime.
+ Zie: <a href="https://github.com/MinBZK/Baseline-Informatiebeveiliging-Overheid/pull/.../changes">Was-wordt</a>
+</p>
+
 
 ### 8.08.06
 

--- a/docs/maatregelen/index.md
+++ b/docs/maatregelen/index.md
@@ -644,7 +644,7 @@ De controle wordt aantoonbaar uitgevoerd; ten minste methode, bevindingen, beoor
 
 <p class="note" title="Deze maatregel is gewijzigd voor BIO2 v2.0.">
  Inhoudelijke verduidelijking en aanscherping van het technische testregime.
- Zie: <a href="https://github.com/MinBZK/Baseline-Informatiebeveiliging-Overheid/pull/.../changes">Was-wordt</a>
+ Zie: <a href="https://github.com/MinBZK/Baseline-Informatiebeveiliging-Overheid/pull/498/changes">Was-wordt</a>
 </p>
 
 ### 8.08.05
@@ -655,7 +655,7 @@ Als uit de penetratietest bevindingen met een hoog risico komen die niet op een 
 
 <p class="note" title="Deze maatregel is gewijzigd voor BIO2 v2.0.">
  Inhoudelijke verduidelijking en aanscherping van het technische testregime.
- Zie: <a href="https://github.com/MinBZK/Baseline-Informatiebeveiliging-Overheid/pull/.../changes">Was-wordt</a>
+ Zie: <a href="https://github.com/MinBZK/Baseline-Informatiebeveiliging-Overheid/pull/498/changes">Was-wordt</a>
 </p>
 
 


### PR DESCRIPTION
## Controlelijst voordat je een beoordeling aangevraagd
- [ ] Ik heb de [contributing guidelines](https://github.com/MinBZK/Baseline-Informatiebeveiliging-Overheid/blob/main/CONTRIBUTING.md) van deze repository gelezen en gevolgd.
- [ ] Ik heb aanpassingen gecontroleerd op taal- en spelfouten en linken gecontroleerd op werking.
- [ ] Deze pull-request gaat naar de juiste branch (in principe mergen we eerst naar de branch `release` alvorens te mergen naar de `main` branch).

## Wijzigingsverzoek

WV #131 en #136 | Maatregelen 8.08.04 en 8.08.05 | Werkgroep BIO 14-07-2026

## Besluit

De Werkgroep BIO heeft ingestemd met herziening van 8.08.04 en 8.08.05 als integraal technisch testpakket.
Na aanvullende afstemming op 20 en 21 juli 2026 is de formulering voor internetfacing-informatiesystemen aangescherpt.

## Status

Goedgekeurd voor verwerking in BIO2 v2.0.

## Impact

Middel-laag

## Type wijziging

Inhoudelijke verduidelijking en aanscherping van het technische testregime.

## Wijzigingen

- 8.08.04 bevat voortaan een minimale jaarlijkse technische controleplicht.
- De wijze en frequentie van controleren blijven risicogebaseerd.
- Internetfacing-informatiesystemen worden continu automatisch gescand of getest op zwakheden en kwetsbaarheden.
- Methode, bevindingen, beoordeling en opvolging worden aantoonbaar vastgelegd.
- Root-cause-analyse en controle op vergelijkbare kwetsbaarheden in andere systemen worden toegevoegd.
- 8.08.05 verplicht een penetratietest bij ingebruikname of majeure wijziging.
- De term “geautomatiseerde penetratietest” vervalt.
- De jaarlijkse testplicht voor internetfacing-systemen wordt via 8.08.04 afgedekt.
- FAQ’s verduidelijken majeure wijzigingen, scans versus pentests, red teaming, OT en samenhang met 8.29.01, 8.31.02 en 8.32.

## Motivering

De huidige teksten bevatten zachte en onduidelijke formuleringen zoals “waar mogelijk”, “kan bijvoorbeeld”, “release” en “major update”. De nieuwe teksten maken de minimale verplichting beter toetsbaar, terwijl methode en frequentie risicogebaseerd blijven. Met de toevoeging “automatisch” wordt verduidelijkt dat continu testen van internetfacing-informatiesystemen niet betekent dat continu handmatig wordt getest.

## Controle

- [ ] ReSpec-build slaagt
- [ ] GitHub Pages-preview gecontroleerd
- [ ] 8.08.04 correct weergegeven
- [ ] 8.08.05 correct weergegeven
- [ ] Jaarlijkse testzin verwijderd uit 8.08.05
- [ ] “continu automatisch gescand of getest” correct opgenomen
- [ ] FAQ’s toegevoegd en gecontroleerd
- [ ] Geen normtekstwijzigingen in 8.29.01, 8.31.02 of 8.32
- [ ] Wijzigingenregister bijgewerkt
- [ ] Was-wordt-lijst bijgewerkt
- [ ] BIO Excel bijgewerkt

