### PR TITLE
WV #455 | 8.24.05 reservecertificaten naar certificaatcontinuiteit

### DIFF
--- a/docs/maatregelen/index.md
+++ b/docs/maatregelen/index.md
@@ -831,7 +831,7 @@ De entiteit heeft maatregelen getroffen om bij uitval, intrekking of verlies van
 
 <p class="note" title="Deze maatregel is gewijzigd voor BIO2 v2.0.">
  Wijziging naar certificaatcontinuïteit
- Zie: <a href="https://github.com/MinBZK/Baseline-Informatiebeveiliging-Overheid/pull/.../changes">Was-wordt</a>
+ Zie: <a href="https://github.com/MinBZK/Baseline-Informatiebeveiliging-Overheid/pull/500/changes">Was-wordt</a>
 </p>
 
 

--- a/docs/maatregelen/index.md
+++ b/docs/maatregelen/index.md
@@ -827,7 +827,13 @@ De sterkte van de cryptografie wordt gebaseerd op de actuele adviezen van het NC
 
 ### 8.24.05
 
-Er zijn afspraken over reservecertificaten van een alternatieve leverancier als uit de risicoafweging blijkt dat deze noodzakelijk zijn als onderdeel van gereedheid voor bedrijfscontinuïteit (zie beheersmaatregel 5.30 uit NEN-EN-ISO/IEC 27002:2022).
+De entiteit heeft maatregelen getroffen om bij uitval, intrekking of verlies van vertrouwen in een certificaatleverancier tijdig te kunnen overschakelen op een passend alternatief. De aard van deze maatregelen volgt uit een risicoafweging. De overweging of een reservecertificaat noodzakelijk is, maakt expliciet onderdeel uit van deze risicoafweging.
+
+<p class="note" title="Deze maatregel is gewijzigd voor BIO2 v2.0.">
+ Wijziging naar certificaatcontinuïteit
+ Zie: <a href="https://github.com/MinBZK/Baseline-Informatiebeveiliging-Overheid/pull/.../changes">Was-wordt</a>
+</p>
+
 
 ### 8.25.01
 


### PR DESCRIPTION
## Controlelijst voordat je een beoordeling aangevraagd
- [x] Ik heb de [contributing guidelines](https://github.com/MinBZK/Baseline-Informatiebeveiliging-Overheid/blob/main/CONTRIBUTING.md) van deze repository gelezen en gevolgd.
- [x] Ik heb aanpassingen gecontroleerd op taal- en spelfouten en linken gecontroleerd op werking.
- [x] Deze pull-request gaat naar de juiste branch (in principe mergen we eerst naar de branch `release` alvorens te mergen naar de `main` branch).

Werkgroep: 14-07-2026 (geaccordeerd Kernteam BIO)  Besluit: aangepast overgenomen
Herkomst: indiener Annemieke-CIP (#455); bijdragen Christian-NCSC-NL, ronaldvanrij

Maatregel 8.24.05 geherformuleerd van een op een oplossing gerichte tekst
("afspraken over reservecertificaten van een alternatieve leverancier") naar een
resultaatgerichte, technologie- en leveranciersneutrale norm gericht op
certificaatcontinuiteit: tijdig kunnen overschakelen bij uitval, intrekking of
verlies van vertrouwen van een certificaatleverancier. De overweging of een
reservecertificaat nodig is, maakt expliciet onderdeel uit van de risicoafweging.

Verwerkt in: werkversie (ReSpec), was-wordt (regel 21), BIO Excel, register (regel 17), FAQ