### PR TITLE
Issue 137-Verduidelijk registratie internetfacing-systemen

### DIFF
--- a/docs/maatregelen/index.md
+++ b/docs/maatregelen/index.md
@@ -144,7 +144,7 @@ Van alle internetfacing-informatiesystemen, websites, IP-adressen, domeinnamen e
 
 <p class="note" title="Deze maatregel is gewijzigd voor BIO2 v2.0.">
   Verduidelijk registratie internetfacing-systemen
-  Zie: <a href="https://github.com/MinBZK/Baseline-Informatiebeveiliging-Overheid/pull/.../changes">Was-wordt</a>
+  Zie: <a href="https://github.com/MinBZK/Baseline-Informatiebeveiliging-Overheid/pull/501/changes">Was-wordt</a>
 </p>
 
 ### 5.14.05

--- a/docs/maatregelen/index.md
+++ b/docs/maatregelen/index.md
@@ -140,7 +140,12 @@ Geavanceerde en/of gekwalificeerde elektronische handtekeningen voldoen aan de A
 
 ### 5.14.04
 
-Van alle internetfacing-informatiesystemen, webapplicaties, IP-adressen en API’s is er een actuele registratie.
+Van alle internetfacing-informatiesystemen, websites, IP-adressen, domeinnamen en API's wordt een actuele registratie bijgehouden.
+
+<p class="note" title="Deze maatregel is gewijzigd voor BIO2 v2.0.">
+  Verduidelijk registratie internetfacing-systemen
+  Zie: <a href="https://github.com/MinBZK/Baseline-Informatiebeveiliging-Overheid/pull/.../changes">Was-wordt</a>
+</p>
 
 ### 5.14.05
 


### PR DESCRIPTION
## Controlelijst voordat je een beoordeling aangevraagd
- [x] Ik heb de [contributing guidelines](https://github.com/MinBZK/Baseline-Informatiebeveiliging-Overheid/blob/main/CONTRIBUTING.md) van deze repository gelezen en gevolgd.
- [x] Ik heb aanpassingen gecontroleerd op taal- en spelfouten en linken gecontroleerd op werking.
- [x] Deze pull-request gaat naar de juiste branch (in principe mergen we eerst naar de branch `release` alvorens te mergen naar de `main` branch).

Werkgroep: 14-07-2026 (eerder behandeld 16-06-2026)  Besluit: aangepast overgenomen
Herkomst: indiener meep1979 (GitHub #137); inhoudelijke bijdragen Christian-NCSC-NL en keeshint

Maatregel 5.14.04 is verduidelijkt: de kwalificatie "internetfacing" geldt nu
expliciet voor alle genoemde categorieen. "websites" en "domeinnamen" zijn
toegevoegd; "webapplicaties" gaat op in "websites/informatiesystemen". Daarmee is
weggenomen dat onduidelijk was of de registratieplicht ook voor alle interne API's
zou gelden.

De registratieplicht blijft beperkt tot het internetfacing-aanvalsoppervlak.
Interne API's vallen buiten deze specifieke registratieplicht, maar blijven geborgd
via andere BIO-maatregelen (5.9 inventarisatie, 8.9 configuratiebeheer, toegangsbeheer,
logging, kwetsbaarhedenbeheer, veilige ontwikkeling). De maatregel schrijft geen
specifiek registratie- of CMDB-product voor. Afgesplitst uit cluster 5.14
(informatieoverdracht). Geen nieuwe verplichting. Toelichting (internetfacing, interne
API's) is via de FAQ opgenomen, niet als normtekst.