### PR TITLE
Issue 151- Wachtwoorden 5.17

### DIFF
--- a/docs/maatregelen/index.md
+++ b/docs/maatregelen/index.md
@@ -178,11 +178,16 @@ De entiteit past MFA toe in deze twee vormen:
 Indien MFA niet mogelijk is voor deze accounts, worden andere mitigerende maatregelen genomen.<br><br>
 Bij het nemen van mitigerende maatregelen wordt de CISO betrokken.<br><br>
 De proceseigenaar keurt de mitigerende maatregelen goed.<br><br>
-Waar mogelijk en veilig wordt MFA met federatieve authenticatievoorzieningen zoals Single Sign On en een Stepping Stone-oplossing worden gecombineerd toegepast.<br><br>
+Waar mogelijk en veilig wordt MFA gecombineerd toegepast met federatieve authenticatievoorzieningen, zoals Single Sign On en een Stepping Stone-oplossing.<br><br>
 Voor beheer en monitoring van authenticatiegegevens:
 
 - wordt authenticatie-informatie uitgegeven met formele vastgestelde procedures, nadat de identiteit van de gebruiker met voldoende zekerheid is vastgesteld;
 - worden Use Cases voor misbruik van authenticatiegegevens gedefinieerd, worden deze gemonitord en wordt passende actie ondernomen bij het optreden ervan. Deze Use Cases omvatten in ieder geval inlogpogingen van ongebruikelijke plekken en pieken in mislukte inlogpogingen.
+
+<p class="note" title="Deze maatregel is gewijzigd voor BIO2 v2.0.">
+  Correctie in formulering
+  Zie: <a href="https://github.com/MinBZK/Baseline-Informatiebeveiliging-Overheid/pull/502/changes">Was-wordt</a>
+</p>
 
 ### 5.17.02
 

--- a/docs/maatregelen/index.md
+++ b/docs/maatregelen/index.md
@@ -195,7 +195,12 @@ De entiteit biedt aan alle medewerkers een wachtwoordmanager of vergelijkbare op
 
 ### 5.17.03
 
-De eisen aan wachtwoorden worden geautomatiseerd afgedwongen.
+Eisen aan wachtwoorden worden geautomatiseerd afgedwongen.
+
+<p class="note" title="Deze maatregel is gewijzigd voor BIO2 v2.0.">
+  Correctie in formulering
+  Zie: <a href="https://github.com/MinBZK/Baseline-Informatiebeveiliging-Overheid/pull/502/changes">Was-wordt</a>
+</p>
 
 ### 5.18.01
 


### PR DESCRIPTION
## Controlelijst voordat je een beoordeling aangevraagd
- [x] Ik heb de [contributing guidelines](https://github.com/MinBZK/Baseline-Informatiebeveiliging-Overheid/blob/main/CONTRIBUTING.md) van deze repository gelezen en gevolgd.
- [x] Ik heb aanpassingen gecontroleerd op taal- en spelfouten en linken gecontroleerd op werking.
- [x] Deze pull-request gaat naar de juiste branch (in principe mergen we eerst naar de branch `release` alvorens te mergen naar de `main` branch).

BIO2 #151 5.17.01-03 wachtwoorden: redactionele correcties + FAQ [laag]

Werkgroep: 14-07-2026 (Kernteam BIO, ter informatie aan de Werkgroep BIO)  Besluit: overgenomen
Herkomst: indiener swinkelsrick (GitHub #151); aanvullingen Christian-NCSC-NL

Verzoek #151 vraagt om explicietere wachtwoordeisen (sterkte, hergebruik,
gecompromitteerd) en om duiding van "geautomatiseerd afdwingen" bij 5.17.03. De
inhoud is niet als nieuwe technische normtekst verwerkt, maar als FAQ/implementatie-
richtlijn bij 5.17.01-03, leveranciersneutraal (het doel, niet het product). De eisen
liggen al besloten in ISO 27002 5.17 en 8.5.

Twee redactionele correcties in de normtekst:
- 5.17.01: de zin over MFA in combinatie met federatieve authenticatievoorzieningen
  is grammaticaal hersteld ("Waar mogelijk en veilig wordt MFA gecombineerd toegepast
  met federatieve authenticatievoorzieningen, zoals Single Sign On en een Stepping
  Stone-oplossing"). Geen inhoudelijke wijziging.
- 5.17.03: "De" aan het begin geschrapt (was "De eisen aan wachtwoorden worden
  geautomatiseerd afgedwongen"; wordt "Eisen aan wachtwoorden worden geautomatiseerd
  afgedwongen"), omdat uit de context niet blijkt naar welke eisen "de eisen" verwijst
  (suggestie Christian-NCSC-NL). Geen inhoudelijke wijziging.
- 5.17.02: geen normtekstwijziging.

MFA blijft hoofdmaatregel (5.17.01). Geen nieuwe verplichting, geen normatieve
verzwaring. Toelichting (wachtwoordeisen, geautomatiseerd afdwingen, browser-autosave)
is via de FAQ opgenomen, niet als normtekst.
