### PR TITLE
WV #53/#443/#457 | 5.14.02 certificaten technologie-neutraal + ACME verplicht

### DIFF
--- a/docs/maatregelen/index.md
+++ b/docs/maatregelen/index.md
@@ -130,9 +130,16 @@ Daarbij dienen alle onderdelen te worden ingesteld zodat een optimale beveiligin
 
 ### 5.14.02
 
-De entiteit maakt bij openbaar webverkeer van gevoelige gegevens gebruik van ten minste publiek vertrouwde Organization Validated (OV)-certificaten.<br><br>
-De entiteit maakt bij intern webverkeer voor gevoelige gegevens gebruik van ten minste publieke vertrouwde OV certificaten of private PKIo-certificaten.<br><br>
-Hogere eisen aan certificaten vloeien voort uit een risicoanalyse, aansluitvoorwaarden of wetgeving.
+Bij publiek toegankelijke websites wordt gebruikgemaakt van publiek vertrouwde TLS-certificaten. 
+
+Deze betreffende certificaten worden tijdig en geautomatiseerd aangevraagd, beheerd en vernieuwd door middel van het ACME-protocol. 
+
+Uit een risicoanalyse kan blijken dat een hoger validatieniveau (OV of EV) nodig is. (Zie ook overheidsmaatregelen 8.24.01 t/m 8.24.05).
+
+<p class="note" title="Deze maatregel is gewijzigd voor BIO2 v2.0.">
+ Verplichte wijze in de normtekst vastgesteld
+  Zie: <a href="https://github.com/MinBZK/Baseline-Informatiebeveiliging-Overheid/pull/503/changes">Was-wordt</a>
+</p>
 
 ### 5.14.03
 


### PR DESCRIPTION
## Controlelijst voordat je een beoordeling aangevraagd
- [x] Ik heb de [contributing guidelines](https://github.com/MinBZK/Baseline-Informatiebeveiliging-Overheid/blob/main/CONTRIBUTING.md) van deze repository gelezen en gevolgd.
- [x] Ik heb aanpassingen gecontroleerd op taal- en spelfouten en linken gecontroleerd op werking.
- [x] Deze pull-request gaat naar de juiste branch (in principe mergen we eerst naar de branch `release` alvorens te mergen naar de `main` branch).

Werkgroep: 14-07-2026 (eerder behandeld 16-06-2026)  Besluit: aangepast overgenomen
Herkomst: indieners GitHub #53, #443, #457 (certificaatspecificiteit); cluster 5.14 Informatieoverdracht

Maatregel 5.14.02 is technologie- en leveranciersneutraal geherformuleerd. Voor
publiek toegankelijke websites wordt gebruikgemaakt van publiek vertrouwde
TLS-certificaten. Geautomatiseerd certificaatbeheer via het ACME-protocol is de
verplichte wijze van aanvragen, beheren en vernieuwen ("waar passend" vervalt).
Voor gevallen waarin ACME feitelijk onuitvoerbaar is (PKIoverheid, air-gapped)
geldt een uitzondering (comply-or-explain).

Het v1.3-onderscheid publiek/intern webverkeer en de vaste OV-ondergrens vervallen;
het passende validatieniveau (DV/OV/EV) volgt uit risicoanalyse, context en
vertrouwensbehoefte. Technische duiding (ACME, CAA, DV/OV/EV, PKIoverheid) staat in
de FAQ, niet als normtekst. Afgesplitst uit cluster 5.14; samenhang met 8.24.05
(certificaatcontinuiteit) en 8.24.01-8.24.04. Impact middel-laag.


